### PR TITLE
Fixed the Jobs tab which is forced to the state scope

### DIFF
--- a/timeline/index.html
+++ b/timeline/index.html
@@ -396,7 +396,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const goals = [
         { goal: "air", name: "Emissions" },
         { goal: "health", name: "Health" },
-        { goal: "jobs", name: "Jobs", extra: "&scope=state" },
+        { goal: "jobs", name: "Jobs" },
         { goal: "economy", name: "Economy" },
         { goal: "biodiverse", name: "Biodiversity" },
         { goal: "water", name: "Water" },


### PR DESCRIPTION
Fix(timeline): remove hardcoded state scope from Jobs tab

The Jobs tab had `extras: "&scope=state"` which forced state scope regardless of data availability. This conflicted with the Top Economies feature which requires country scope.

Removed the extras parameter to allow Jobs tab to behave like other tabs, loading scope from Google Sheet Row 1 data.