### PR TITLE
Add toggle functionality for size controls

### DIFF
--- a/timeline/index.html
+++ b/timeline/index.html
@@ -532,7 +532,10 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
 
         <!-- Chart Size Controls -->
-        <div style="clear: both; margin: 20px 0; padding: 15px; background-color: #f8f9fa; border-radius: 8px; border: 1px solid #dee2e6;">
+        <button onclick="showControl()" style="border: none; cursor: pointer; background:none;">
+            <svg width="22" height="22" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="iconify iconify--twemoji" preserveAspectRatio="xMidYMid meet"><path fill="#66757F" d="M34 15h-3.362a12.915 12.915 0 0 0-1.582-3.814l2.379-2.379a2 2 0 0 0 0-2.829l-1.414-1.414a2 2 0 0 0-2.828 0l-2.379 2.379A12.924 12.924 0 0 0 21 5.362V2a2 2 0 0 0-2-2h-2a2 2 0 0 0-2 2v3.362a12.915 12.915 0 0 0-3.814 1.582L8.808 4.565a2 2 0 0 0-2.828 0L4.565 5.979a2.002 2.002 0 0 0-.001 2.829l2.379 2.379A12.918 12.918 0 0 0 5.362 15H2a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h3.362a12.92 12.92 0 0 0 1.582 3.813l-2.379 2.379c-.78.78-.78 2.048.001 2.829l1.414 1.414c.78.78 2.047.78 2.828 0l2.379-2.379a12.889 12.889 0 0 0 3.814 1.582V34a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2v-3.362a12.92 12.92 0 0 0 3.813-1.582l2.379 2.379a2 2 0 0 0 2.828 0l1.414-1.414a2 2 0 0 0 0-2.829l-2.379-2.379a12.889 12.889 0 0 0 1.582-3.814H34a2 2 0 0 0 2-2v-2A2 2 0 0 0 34 15zM18 26a8 8 0 1 1 0-16a8 8 0 0 1 0 16z"></path></svg>
+        </button>
+        <div class="size-control-gear" style="display: none; clear: both; margin: 20px 0; padding: 15px; background-color: #f8f9fa; border-radius: 8px; border: 1px solid #dee2e6;">
             <h4 style="margin: 0 0 15px 0; color: #495057; font-size: 16px;">Chart Size Controls</h4>
             <div style="display: flex; align-items: center; gap: 20px; flex-wrap: wrap;">
                 <div style="display: flex; align-items: center; gap: 10px;">
@@ -553,6 +556,19 @@ document.addEventListener('DOMContentLoaded', () => {
                 </button>
             </div>
         </div>
+
+        <script>
+        function showControl() {
+            const sizeControl = document.querySelector('.size-control-gear');
+            if (sizeControl) {
+                if (sizeControl.style.display === 'none') {
+                    sizeControl.style.display = 'block';
+                } else {
+                    sizeControl.style.display = 'none';
+                }
+            }
+        }
+        </script>
 
         <div id="div1" class="toogleDiv" chart-wrapper>
             <canvas id="timelineChart" ></canvas>


### PR DESCRIPTION
Worked on the following TODO in https://github.com/modelearth/projects/issues/28
TO DO: The "Chart Size Controls" sliders aren't currently helpful. Hide and add a settings (gear) icon to reveal them.

Added gear icon to toggle display the chart size control
<img width="2214" height="860" alt="image" src="https://github.com/user-attachments/assets/7a9ab9fb-e286-483a-9fd4-a371d648ff2f" />
<img width="2264" height="618" alt="image" src="https://github.com/user-attachments/assets/992ac175-2ae3-4e70-8a81-ebfeeb0e5fea" />
