### PR TITLE
Implement lazy loading for country data on Timeline page

### DIFF
--- a/js/earthscape.js
+++ b/js/earthscape.js
@@ -1197,13 +1197,13 @@ function updateAllCountryLabel(count) {
         // Find the "All" radio button's parent label
         const allRadio = document.querySelector('input[name="whichLines"][value="showAll"]');
         if (allRadio && allRadio.parentElement) {
-            // Update the label text to show count
+            // Update the label text to show count in parentheses
             const labelText = allRadio.parentElement.childNodes;
             // Find the text node and update it
             for (let i = 0; i < labelText.length; i++) {
                 if (labelText[i].nodeType === Node.TEXT_NODE && labelText[i].textContent.includes('All')) {
-                    labelText[i].textContent = `All ${count} `;
-                    console.log(`Updated "All" label to "All ${count}"`);
+                    labelText[i].textContent = `All (${count}) `;
+                    console.log(`Updated "All" label to "All (${count})"`);
                     break;
                 }
             }

--- a/js/earthscape.js
+++ b/js/earthscape.js
@@ -526,10 +526,16 @@ dataCopy.forEach(location => {
     } else {
         selectedData = dataCopy;
         // Update label with actual count of countries that have data
-        if (scope === "country") {
+        if (scope === "country" && showAll === 'showAll') {
             updateAllCountryLabel(selectedData.length);
         }
     }
+
+    // Reset the "All" label when other modes are selected
+    if (scope === "country" && showAll !== 'showAll') {
+        resetAllCountryLabel();
+    }
+
      console.log("Filtered Countries:", selectedData);
 
     // Get datasets
@@ -1210,6 +1216,28 @@ function updateAllCountryLabel(count) {
         }
     } catch (error) {
         console.warn('Could not update All label:', error);
+    }
+}
+
+// Function to reset the "All" radio button label (remove count)
+function resetAllCountryLabel() {
+    try {
+        // Find the "All" radio button's parent label
+        const allRadio = document.querySelector('input[name="whichLines"][value="showAll"]');
+        if (allRadio && allRadio.parentElement) {
+            // Reset the label text to just "All"
+            const labelText = allRadio.parentElement.childNodes;
+            // Find the text node and reset it
+            for (let i = 0; i < labelText.length; i++) {
+                if (labelText[i].nodeType === Node.TEXT_NODE && (labelText[i].textContent.includes('All'))) {
+                    labelText[i].textContent = 'All ';
+                    console.log('Reset "All" label to just "All"');
+                    break;
+                }
+            }
+        }
+    } catch (error) {
+        console.warn('Could not reset All label:', error);
     }
 }
 

--- a/js/earthscape.js
+++ b/js/earthscape.js
@@ -292,10 +292,8 @@ async function getTimelineChart(scope, chartVariable, entityId, showAll, chartTe
 
                 // Cache the result
                 allCountriesCache = countriesData.map(country => country.cca2).filter(Boolean);
-                console.log(`Loaded ${allCountriesCache.length} countries`);
-
-                // Update the "All" label with count
-                updateAllCountryLabel(allCountriesCache.length);
+                console.log(`Loaded ${allCountriesCache.length} countries from API`);
+                // Note: Label will be updated later with actual count of countries that have data
             } else {
                 console.log("Using cached country data");
             }
@@ -524,9 +522,13 @@ dataCopy.forEach(location => {
                 : a.latestValue - b.latestValue
         )
         .slice(0, Math.min(5, validData.length));
-            
+
     } else {
         selectedData = dataCopy;
+        // Update label with actual count of countries that have data
+        if (scope === "country") {
+            updateAllCountryLabel(selectedData.length);
+        }
     }
      console.log("Filtered Countries:", selectedData);
 


### PR DESCRIPTION
# Implement lazy loading for country data on Timeline page

This PR adds lazy loading for country data on the Timeline page to improve performance and meet the requirements from issue #28. Instead of fetching all countries on every page load, data from the RESTCountries API is now fetched only when the user selects the "All" option.

## What this change does

- Loads country data only when the "All" radio button is clicked
- Caches the fetched country list to prevent repeated API calls
- Uses a predefined list of 11 countries for Top 5, Bottom 5, and Top Economics views
- Updates the "All" label to show the actual number of countries once data is loaded
- Resets the label back to "All" when switching to other display modes

## UI behaviour

- The label updates dynamically to the format `All (X)`, where X reflects the number of countries with data for the selected metric
- The count varies based on data availability for each metric
- No label update occurs until data has been loaded

## Technical details

- Lazy loading logic added in `js/earthscape.js`
- Country data is fetched once and reused on subsequent selections
- No API calls occur during the initial page load

## Performance impact

### Before
- RESTCountries API called on every page load
- All countries fetched regardless of user selection
- Slower initial render and unnecessary network usage

### After
- No API call on initial load
- API request triggered only when "All" is selected
- Cached data used on subsequent selections
- Faster initial page load

## Testing

- Verified no RESTCountries API call on initial load
- Verified API call occurs only when "All" is clicked
- Confirmed label updates correctly with dynamic counts
- Confirmed label resets when switching display modes
- Verified Top 5, Bottom 5, and Top Economics modes continue to work as expected

## Files changed

- `js/earthscape.js`

## Related issue

Addresses the lazy loading requirements in issue #28
