### PR TITLE
updated navigation text and functionality

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -7937,29 +7937,29 @@ $(document).on("change", "#selectScope", function(event) {
     goHash({'scope':this.value});
 });
 // Click handler for State Name Tab - Shows inline dropdown
-$(document).on("click", "#filterClickState", function(event) {
-    // Toggle inline state dropdown
-    const inlineDropdown = $("#inlineStateDropdown");
+// $(document).on("click", "#filterClickState", function(event) {
+//     // Toggle inline state dropdown
+//     const inlineDropdown = $("#inlineStateDropdown");
     
-    if (inlineDropdown.is(':visible')) {
-        inlineDropdown.hide();
-    } else {
-        // Move state_select to inline dropdown
-        if (typeof state_select != "undefined") {
-            inlineDropdown.empty();
-            const stateSelectClone = $(state_select).clone();
-            stateSelectClone.attr('id', 'state_select_inline').show();
-            stateSelectClone.val($("#state_select").val());
-            stateSelectClone.on('change', function() {
-                $("#state_select").val($(this).val()).trigger('change');
-                inlineDropdown.hide();
-            });
-            inlineDropdown.append(stateSelectClone);
-            inlineDropdown.show();
-        }
-    }
-    event.stopPropagation();
-});
+//     if (inlineDropdown.is(':visible')) {
+//         inlineDropdown.hide();
+//     } else {
+//         // Move state_select to inline dropdown
+//         if (typeof state_select != "undefined") {
+//             inlineDropdown.empty();
+//             const stateSelectClone = $(state_select).clone();
+//             stateSelectClone.attr('id', 'state_select_inline').show();
+//             stateSelectClone.val($("#state_select").val());
+//             stateSelectClone.on('change', function() {
+//                 $("#state_select").val($(this).val()).trigger('change');
+//                 inlineDropdown.hide();
+//             });
+//             inlineDropdown.append(stateSelectClone);
+//             inlineDropdown.show();
+//         }
+//     }
+//     event.stopPropagation();
+// });
 
 // Close inline dropdown when clicking elsewhere
 $(document).on("click", function(event) {
@@ -7968,9 +7968,8 @@ $(document).on("click", function(event) {
         $("#inlineStateDropdown").hide();
     }
 });
-
 // Click handler for Counties Tab - Opens location filter panel
-$(document).on("click", "#filterClickLocation", function(event) {
+$(document).on("click", "#filterClickLocation, #filterClickState", function(event) {
 
     if ($("#draggableSearch").is(':visible')) {
         $("#draggableSearch").hide();

--- a/map/filter.html
+++ b/map/filter.html
@@ -77,7 +77,7 @@
             <div style="position:relative;">
               <!-- State Name Tab - Shows state dropdown when clicked -->
               <div class="filterClick" id="filterClickState" style="display:none; float:left; margin-right: 4px;">
-                <div class="filterClickText locationTabText">United States</div>
+                <div class="filterClickText locationTabText">Countries</div>
               </div>
               
               <!-- State Dropdown Container - Appears inline when state tab is clicked -->


### PR DESCRIPTION
update the top navigation to show the word "Countries" instead of "United States" by default. Clicking 'Countries' routes to  https://model.earth/community/#geoview=countries
<img width="1386" height="496" alt="image" src="https://github.com/user-attachments/assets/f808f9c4-09e4-484c-a4d2-cf60118fadfd" />
<img width="1856" height="552" alt="image" src="https://github.com/user-attachments/assets/ba2a87a6-437d-4d22-9b75-34d703b85723" />
