### PR TITLE
Fix NAICS hash redirect and Industry Detail Dashboard visibility

### DIFF
--- a/js/industry-detail.js
+++ b/js/industry-detail.js
@@ -26,7 +26,11 @@ let allProductFiles = [];
  */
 async function initIndustryDetail() {
     try {
-        const response = await fetch('/io/naics/product-category-mapping.json');
+        // Use full URL for GitHub Pages, relative path for localhost
+        const baseUrl = window.location.hostname.includes('github.io')
+            ? 'https://mohammed-saalim.github.io'
+            : '';
+        const response = await fetch(`${baseUrl}/io/naics/product-category-mapping.json`);
         if (response.ok) {
             productCategoryMapping = await response.json();
             console.log('[IndustryDetail] Product mapping loaded:', Object.keys(productCategoryMapping.mappings).length, 'categories');

--- a/js/naics.js
+++ b/js/naics.js
@@ -308,7 +308,7 @@ function refreshNaicsWidget(initialLoad) {
         }
 
         // v2
-        if ((location.host.indexOf('localhost') >= 0 || hash.beta == "true") || location.href.indexOf('/info/naics/') >= 0) {
+        if ((location.host.indexOf('localhost') >= 0 || hash.beta == "true") || location.href.indexOf('/info/naics/') >= 0 || location.host.indexOf('github.io') >= 0) {
 
             $("#industryTableHolder").show();
             $("#sectorTableHolder").show();

--- a/js/naics.js
+++ b/js/naics.js
@@ -1990,18 +1990,18 @@ function topRatesInFipsNew(dataSet, fips) {
     let currentHash = getHash();
     if (currentHash.naics && typeof updateIndustryStats === 'function') {
         // Aggregate county-level data for this NAICS code
-        if (dataSet.industryCounties && dataSet.industryCounties.length > 0) {
+        if (localObject.industryCounties && localObject.industryCounties.length > 0) {
             let totalEmployees = 0;
             let totalEstablishments = 0;
             let totalPayroll = 0;
             let countyCount = 0;
 
-            for (let i = 0; i < dataSet.industryCounties.length; i++) {
+            for (let i = 0; i < localObject.industryCounties.length; i++) {
                 // Property is "Naics" not "NAICS"
-                if (dataSet.industryCounties[i].Naics === currentHash.naics || dataSet.industryCounties[i].Naics === String(currentHash.naics)) {
-                    totalEmployees += Number(dataSet.industryCounties[i]['Employees']) || 0;
-                    totalEstablishments += Number(dataSet.industryCounties[i]['Establishments']) || 0;
-                    totalPayroll += Number(dataSet.industryCounties[i]['Payroll']) || 0;
+                if (localObject.industryCounties[i].Naics === currentHash.naics || localObject.industryCounties[i].Naics === String(currentHash.naics)) {
+                    totalEmployees += Number(localObject.industryCounties[i]['Employees']) || 0;
+                    totalEstablishments += Number(localObject.industryCounties[i]['Establishments']) || 0;
+                    totalPayroll += Number(localObject.industryCounties[i]['Payroll']) || 0;
                     countyCount++;
                 }
             }
@@ -2017,7 +2017,7 @@ function topRatesInFipsNew(dataSet, fips) {
                 console.warn('[IndustryStats] No county data found for NAICS', currentHash.naics);
             }
         } else {
-            console.warn('[IndustryStats] dataSet.industryCounties not available');
+            console.warn('[IndustryStats] localObject.industryCounties not available');
         }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes three critical issues preventing the Industry Detail Dashboard from displaying when users navigate to direct NAICS links (e.g., `#state=GA&naics=622110`):

✅ **Hash Preservation** - NAICS parameter now stays in URL for bookmarking  
✅ **Dashboard Trigger** - Single NAICS codes now trigger the dashboard  
✅ **Visibility Fix** - Parent container shown to allow dashboard display  

## Changes

### 1. Hash Preservation (`js/naics.js` lines 542-551)
**Problem**: `updateHash({'naics':''})` was unconditionally clearing the naics parameter from the URL, breaking bookmarking and direct links.

**Solution**: Added conditional check using `getHashOnly()` to preserve user-provided NAICS parameters:
```javascript
let currentUrlHash = getHashOnly();
if (!currentUrlHash.naics) {
    updateHash({'naics':''})
}
