### PR TITLE
refactor(api-keys): single input row; add saves to list and clears row

### DIFF
--- a/tools/storage/api/README.md
+++ b/tools/storage/api/README.md
@@ -1,3 +1,50 @@
+# API Key Form
+
+This page ([index.html](index.html)) is a form for storing API provider names and API keys in the browser. Keys are kept in local storage and can be copied or pasted to move them between browsers.
+
+## Current behaviour
+
+**Single input row**
+- There is one fixed input row: provider dropdown, optional "Other" field, and API key field (with show/hide).
+- When you choose a provider and enter an API key, click **Add** to save. The key is added to storage and shown in the YAML box below; the input row is then cleared so you can enter the next key in the same place. The page does not grow with multiple repeating sections.
+
+**Storage**
+- Data is stored in `localStorage` under the key `aPro` as **JSON**.
+- Each key in the object is a **provider name**; the value is the API key string.
+- Duplicate providers use **parentheses**: first is `"GitHub"`, second is `"GitHub (2)"`, then `"GitHub (3)"`, and so on.
+
+**Provider list**
+- The dropdown offers 19 fixed providers: Azure AI, Building Transparency, Claude AI, Cohere AI, Data Commons, Dreamstudio AI, ChatGPT Pro, ChatGPT Assistant, Fireworks AI, Gemini AI, GitHub, Groq, Mistral AI, NVIDIA, Observable, Replicate, Serp, Together AI, X.com.
+- **"Other"** is also an option; when selected, a text field appears for a custom provider name.
+
+**Copy**
+- The main textarea shows `aPro` as **YAML** (order matches key order).
+- **"Copy"** selects that YAML and copies it to the clipboard.
+- **"Close"** hides the output area and the Close button.
+
+**Update (main textarea)**
+- The user can edit the YAML in the main textarea and click **"Update"**.
+- The page parses that YAML into `aPro`, then refreshes the display. If the YAML has duplicate top-level keys, an alert appears: "Duplicate provides. Please add (2) after second instance." and the update is not applied.
+
+**Paste**
+- **"Paste"** shows a second textarea (`aProInput`).
+- The handler on **input** parses the pasted string as **JSON** (not YAML) and merges keys into `aPro` (same provider is not overwritten; duplicates get numbered keys like `(2)`). Display is then refreshed. The paste-from-another-browser flow is **JSON-based**.
+
+**Clear All**
+- **"Clear All"** immediately clears `aPro` from localStorage and resets the form to one empty input row. There is no "Enter YES" prompt and no confirmation message.
+
+**Undo**
+- Before some actions (e.g. Add, Update, Clear All), the previous state is saved.
+- **"Undo"** appears and restores that state if used within 10 minutes; after that the backup is removed.
+
+**Dependencies**
+- jQuery, js-yaml, [base.css](../../../css/base.css), [localsite.js](../../../js/localsite.js).
+
+---
+
+## History
+
+The form was originally generated from a prompt given to ChatGPT 3.5 and has been updated since (e.g. single input row with Add-then-clear, JSON storage, YAML for display/copy, duplicate keys as `Provider (2)`, Undo, show/hide key). The original spec described multiple repeating panels and a "Clear All" confirmation with "Enter YES"; the current behaviour differs as above.
 
 <!--
 id is appended below to avoid reloading
@@ -5,39 +52,10 @@ id is appended below to avoid reloading
 <!--
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" id="/localsite/js/jquery.min.js"></script>
 -->
-
-
-
 <!--
 https://chat.openai.com/c/94f107ae-5e51-4719-b64f-651eaa7f2b27
 https://chat.openai.com/share/82ca2102-1acd-4e94-8581-280365e012e3
 -->
-# About ChatGPT Dev
-
-There was still a lot of tweaking to get the form elements looking good.
-The following would have benefited from more guidance about css and layout.
-Should have told it to:
-
-## Provided to ChatGPT 3.5
-
-Create a JQuery Web form for choosing API Providers and entering API keys for each provider using a repeating form section called aProviders that initially shows one section panel followed by an "Add API" button. As changes are made, update an object stored in localStorage call aPro and use that object to repopulate form content when reloading the html page.
-
-On the right side of the repeating aProviders form section panel, include a div with style="float:left;" that contains one dropdown menu with id="apiProvider1" with the title over over the dropdown element being "API Provider". The dropdown should show "Select a provider..." prior to making a selection. Add a blank value attribute to the first option in the 'apiProvider' dropdown.
-
-The API Provider dropdown should contain 20 popular API providers in alphabetical order followed with the choice "Other". Include the following in the list of API Providers: Observable API, Google Data Commons, ChatGPT Pro, ChatGPT Assistant, GitHub, Replicate API, Building Transparency.  Include additional popular API Providers in this list so the total is 25.  When "Other" is selected, reveal a text field with id="apiProviderOther1" below the dropdown with the placeholder text "Other Provider". When "Other" is not selected in the apiProvider dropdown, hide the apiProviderOther text field.
-
-To the right of the API Provider div, include an adjacent div with style="overflow:auto" containing a text input field id="apiKey1" with text over it saying "API Key". Use css to make this right div (in the repeating section) fall under the left div when the screen is narrow. When an apiKey text field is cleared, delete the corresponding key-value pair in the aPro object which is stored in localStorage. If the user hits return while their cursor is in a cleared field containing no text, hide that repeating section, unless it is the first repeating section.
-
-Display an "Add API" button for revealing additional instances of the repeating sections so the user can add additional API keys, up to 50.  As section panels are added, increment the panel form element id numbers - so the second panel instance would contain: apiProvider2, apiProviderOther2 and apiKey2. When changes are made, update an object in localStorage called aPro with key-value pairs . Use the apiProvider selections (and apiProviderOther value when visible and not blank) as the keys and the apiKey text entered as the value. If the "Other" option is selected, use the API Provider title entered in the other text field as the key. When using the API Providers as keys in the aPro object, replace spaces with underscores. If the incoming key-value pairs have the same API Provider more than once, in the key name append "2" to the second repetition, append "3" after the third, etc. Avoid appending "1" to the first instance. 
-
-When the html page is reloaded, display and populate repeating aProviders panels using a function that uses the key-value pairs from the aPro object pulled from localStorage. To find key matches in the dropdown, modify the key by removing the number appended to the right of the apiProvider key names and replace underscores with spaces. If a match is not found in the dropdown options, display this modified key in the panel's apiProviderOther field, show the apiProviderOther field and set the panel's dropdown to "Other".
-
-Provide a "Copy" button that allows the user to copy the aPro object as yaml from a textarea with id="aProOutput" revealed when clicking the "Copy" button. Also copy the yaml into their clipboard when they click "Copy". Display a "Close" button after the aProOutput textarea. When clicking "Close", hide the aProOutput textarea and hide the ""Close" button.
-
-Provide a "Paste" button that reveals a textarea with id="aProInput" for the user to paste the copied yaml string to add keys. When they click an "Update" button below the aProInput textarea, add the key-value pairs from the pasted yaml to the aPro object in localStorage as long as the incoming key-value pairs are not already represented. When checking if a key-value pair is already represented, exclude the appended numbers on the right side of both the existing object keys and the incoming keys from the yaml during comparisons of API Provider strings. Only replace a key-value pair if the incoming yaml key string exactly matches an apiProvider key string in the aPro object. When inserting into the aPro object, append numbers starting with 2 if the API Provider already exists in the aPro object. If 2 already exist, then append 3, etc.
-
-Include a "Clear All" button that prompts the user: Are you sure? Enter "YES" to proceed. Show a text field for typing in the word YES.  If the user enters "YES" and hits return, then clear the aPro object from localStorage and set all the repeating sections to blank. Display a confirmation: Your API Keys have been cleared from local storage, and hide the field where they entered "YES".
-
 <!--
 #3498db, #2980b9 (Blue)
 #2ecc71, #27ae60 (Green)
@@ -49,64 +67,4 @@ Include a "Clear All" button that prompts the user: Are you sure? Enter "YES" to
 #34495e, #2c3e50 (Navy)
 #f1c40f, #f39c12 (Yellow)
 #95a5a6, #7f8c8d (Grey)
--->
-
-<!--
-		function generateRepeatingSectionVerbose(index) {
-	  var popularProviders = [
-	    "Amazon Web Services (AWS)",
-	    "Building Transparency API",
-	    "ChatGPT Assistant API",
-	    "ChatGPT Pro API",
-	    "Dropbox API",
-	    "eBay API",
-	    "Facebook Graph API",
-	    "GitHub API",
-	    "Google API",
-	    "Google Data Commons API",
-	    "IBM Watson API",
-	    "Instagram Graph API",
-	    "LinkedIn API",
-	    "Mailchimp API",
-	    "Microsoft Azure API",
-	    "Observable API",
-	    "PayPal API",
-	    "Reddit API",
-	    "Replicate API",
-	    "Salesforce API",
-	    "SendGrid API",
-	    "Shopify API",
-	    "Slack API",
-	    "Spotify Web API",
-	    "Stripe API",
-	    "Twilio API",
-	    "Twitter API",
-	    "Yelp API",
-	    "YouTube API",
-	    "Zoom API"
-	  ];
-
-	  popularProviders.sort();
-
-	  var html = '<div class="repeating-section" id="panel' + index + '">' +
-	             '  <div style="float: left;">' +
-	             '    <label for="apiProvider' + index + '">API Provider</label>' +
-	             '    <select id="apiProvider' + index + '">' +
-	             '      <option>Select a provider...</option>';
-
-	  for (var i = 0; i < popularProviders.length; i++) {
-	    html += '<option>' + popularProviders[i] + '</option>';
-	  }
-
-	  html += '      <option>Other</option>' +
-	          '    </select>' +
-	          '    <input type="text" id="apiProviderOther' + index + '" placeholder="Other Provider" style="display: none;">' +
-	          '  </div>' +
-	          '  <div style="overflow: auto;">' +
-	          '    <label for="apiKey' + index + '">API Key</label>' +
-	          '    <input type="text" id="apiKey' + index + '">' +
-	          '  </div>' +
-	          '</div>';
-	  return html;
-	}
 -->

--- a/tools/storage/api/index.html
+++ b/tools/storage/api/index.html
@@ -13,17 +13,13 @@
 <script type="text/javascript" src="../../../js/localsite.js?showheader=true"></script>
 
 <script>
-// A jQuery form for choosing API Providers and entering API keys for each provider 
-// using a repeating form that initially shows one section panel followed by an "Add API" button. 
-// As changes are made, updates an object stored in localStorage call aPro.
-// when reloading the html page, aPro object is used to repopulate form content.
+// Single input row: user selects provider and enters API key, then clicks Add.
+// The key is saved to aPro and shown in the YAML box below; the input row clears for the next key.
 
 $(document).ready(function() {
 	// An object containing API Providers and API Keys as key-value pairs
 	var aPro = {};
 	var undoTimer = null;
-	// Track which aPro key each panel corresponds to
-	var panelToKeyMap = {}; // panelIndex -> aProKey
 	
 	function isValidJSON(str) {
 		try {
@@ -62,29 +58,12 @@ $(document).ready(function() {
 		}
 	}
 	
-	// Build aPro object in the same order as the form panels
+	// Build aPro for YAML display (preserve key order)
 	function buildOrderedAPro() {
 		let orderedObj = {};
-		
-		// Get all panel indices in order
-		let panelIndices = [];
-		$('.repeating-section').each(function() {
-			let panelId = $(this).attr('id');
-			let index = parseInt(panelId.replace('panel', ''));
-			panelIndices.push(index);
+		Object.keys(aPro).forEach(function(k) {
+			orderedObj[k] = aPro[k];
 		});
-		
-		// Sort indices numerically
-		panelIndices.sort((a, b) => a - b);
-		
-		// Build ordered object based on panel order
-		panelIndices.forEach(index => {
-			let aProKey = panelToKeyMap[index];
-			if (aProKey && aPro.hasOwnProperty(aProKey)) {
-				orderedObj[aProKey] = aPro[aProKey];
-			}
-		});
-		
 		return orderedObj;
 	}
 
@@ -156,230 +135,60 @@ $(document).ready(function() {
 	  return html;
 	}
 
-	// Apply key-value pairs from the local storage object to the panels
+	// Ensure exactly one input row exists (empty). All stored keys are shown in the YAML box below.
+	function ensureSingleInputRow() {
+		$('#formContainer').empty();
+		$('#formContainer').append(generateRepeatingSection(1));
+	}
+
+	function clearInputRow() {
+		$('#apiProvider1').val("");
+		$('#apiKey1').val("");
+		$('#apiProviderOther1').val("").hide();
+		// Reset eye toggle to masked state if visible
+		var keyInput = document.getElementById('apiKey1');
+		if (keyInput && keyInput.className.indexOf('hiddenInput') === -1) {
+			keyInput.className = 'textInput hiddenInput';
+		}
+	}
+
+	// Kept for call sites; now just ensures one row and refreshes YAML
 	function populateRepeatingSections() {
-		// Clear existing mappings
-		panelToKeyMap = {};
-		
-		// Clears form and re-renders panels
-	  $('#formContainer').empty();
-	  let index = 1;
-	  for (var key in aPro) {
-	    $('#formContainer').append(generateRepeatingSection(index)); // Add blank panel to populate
-	    
-	    // Store the mapping between panel and aPro key
-	    panelToKeyMap[index] = key;
-	    
-	    let keyOnly = key.replace(/\s*\(\d+\)$/, ""); // Remove number in parenthesis at end.
-	    if (apiKeys.includes(keyOnly)) {
-		    $('#apiProvider' + index).val(keyOnly);
-		} else {
-			$('#apiProvider' + index).val('Other');
-			$('#apiProviderOther' + index).val(key).show();
-		}
-	    
-	    if ($('#apiProvider' + index).val() == 'Other') {
-	    	$('#apiProviderOther' + index).show();
-	    }
-
-	    $('#apiKey' + index).val(aPro[key]);
-	    
-	    index++;
-	  }
-	  
-	  if (JSON.stringify(aPro) === "{}") {
-	  	$('#aProOutput').val("");
-	  	$('#aProOutputYaml').val("");
-	  } else {
-		  $('#aProOutput').val(JSON.stringify(aPro, null, 2));
-		  if (typeof jsyaml != "undefined") {
-		  	let orderedAPro = buildOrderedAPro();
-		  	let yamlString = jsyaml.dump(orderedAPro);
-			  $('#aProOutputYaml').val(yamlString);
-			  $('#copyBtn').show();
-			}
-		}
-	}
-
-	// INIT
-	populateRepeatingSections();
-	if ($('.repeating-section').length == 0) {
-	  $('#formContainer').append(generateRepeatingSection(1));
-	}
-
-	$('#addApi').click(function() {
-	  var newIndex = $('.repeating-section').length + 1;
-	  $('#formContainer').append(generateRepeatingSection(newIndex));
-	});
-
-	$(document).on('change', 'select[id^="apiProvider"]', function() { // Changing provider dropdown
-	  var index = $(this).attr('id').match(/\d+/)[0];
-	  console.log("Change index " + index);
-	  
-	  var oldKey = $(this).data('previous-value'); // Get previous value
-	  var newKey = $(this).val(); // Get new value
-	  var currentApiKey = $("#apiKey" + index).val();
-	  
-	  // If changing from "Other" to a dropdown option, we need to clean up
-	  if ($(this).data('was-other') === true && newKey !== 'Other') {
-	    // Find and delete the old "other" entry from aPro using our mapping
-	    var oldAProKey = panelToKeyMap[index];
-	    if (oldAProKey) {
-	      delete aPro[oldAProKey];
-	      delete panelToKeyMap[index]; // Clear the mapping
-	    }
-	    
-	    // Clear the API key field
-	    $("#apiKey" + index).val('');
-	    currentApiKey = '';
-	    
-	    // Hide the "other" input field
-	    $('#apiProviderOther' + index).hide();
-	  }
-	  
-	  // Update data attributes for next time
-	  $(this).data('previous-value', newKey);
-	  $(this).data('was-other', newKey === 'Other');
-	  
-	  if (newKey == 'Other') {
-	    $('#apiProviderOther' + index).show();
-	  } else {
-	    $('#apiProviderOther' + index).hide();
-	  }
-	  
-	  // Only update if there's an API key value
-	  if (currentApiKey) {
-	    updateApiRow(index, newKey, currentApiKey);
-	  } else {
-	    // Update storage to reflect the deletion
-	    updateLocalStorage();
-	  }
-	});
-
-	// Initialize data attributes when sections are created
-	$(document).on('focus', 'select[id^="apiProvider"]', function() {
-	  if (!$(this).data('previous-value')) {
-	    $(this).data('previous-value', $(this).val());
-	    $(this).data('was-other', $(this).val() === 'Other');
-	  }
-	});
-
-	// Auto-update on blur for API key fields
-	$(document).on('blur', 'input[id^="apiKey"]', function(e) {
-		// Check if the user clicked on the Update button - if so, avoid double update
-		if (e.relatedTarget && e.relatedTarget.id === 'updateBtn') {
-			return;
-		}
-		
-		let index = $(this).attr('id').match(/\d+/)[0];
-		let key = $("#apiProvider" + index).val();
-		let value = $(this).val();
-		
-		console.log("Blur event - index:", index, "key:", key, "value:", value);
-		
-		if (key) {
-			if (key == 'Other') {
-				key = $("#apiProviderOther" + index).val();
-			}
-			
-			saveUndoState();
-			
-			if (!value) { // Deleting Row by clearing API Key
-				console.log("Delete apiProvider " + key);
-				// Use mapping to find the correct key to delete
-				var oldAProKey = panelToKeyMap[index];
-				if (oldAProKey) {
-					delete aPro[oldAProKey];
-					delete panelToKeyMap[index];
-				}
-				$('#panel' + index).remove();
-			} else {
-				updateApiRow(index, key, value);
-			}
-			
-			updateLocalStorage();
-		}
-	});
-
-	// Handle typing in API key field
-	$(document).on('input', 'input[id^="apiKey"]', function() {
-	  let index = $(this).attr('id').match(/\d+/)[0];
-	  let key = $("#apiProvider" + index).val();
-	  let value = $(this).val();
-	  
-	  if (key) {
-		if (key == 'Other') {
-			key = $("#apiProviderOther" + index).val();
-		}
-		
-		if (!value) { // Deleting Row by clearing API Key
-			console.log("Delete apiProvider " + key);
-			// Use mapping to find the correct key to delete
-			var oldAProKey = panelToKeyMap[index];
-			if (oldAProKey) {
-				delete aPro[oldAProKey];
-				delete panelToKeyMap[index];
-			}
-			updateLocalStorage();
-			$('#panel' + index).remove();
-		} else {
-			updateApiRow(index, key, value);
-		}
-	  }
-	});
-
-	// Handle typing in "Other" provider name field
-	$(document).on('input', 'input[id^="apiProviderOther"]', function() {
-		let index = $(this).attr('id').match(/\d+/)[0];
-		let key = $(this).val();
-		let value = $("#apiKey" + index).val();
-		
-		if (key && value) {
-			updateApiRow(index, key, value);
-		}
-	});
-
-	function updateApiRow(index, key, value) {
-		let apiProviderStr = $('#apiProvider' + index).val();
-		if (apiProviderStr === 'Other') {
-			apiProviderStr = $('#apiProviderOther' + index).val();
-		}
-		
-		if (!apiProviderStr || !value) {
-			return; // Don't update if key or value is empty
-		}
-		
-		// Clean the provider string
-		apiProviderStr = apiProviderStr.replace(/\s*\(\d+\)$/, ""); // Remove number in parenthesis at end.
-		
-		// Check if we're updating an existing entry
-		var existingAProKey = panelToKeyMap[index];
-		
-		if (existingAProKey) {
-			// We're updating an existing entry
-			// If the provider name changed, we need to update the key
-			if (existingAProKey !== apiProviderStr && !existingAProKey.startsWith(apiProviderStr + ' (')) {
-				// Provider name changed, delete old entry
-				delete aPro[existingAProKey];
-				
-				// Create new key with proper numbering
-				let finalKey = generateUniqueKey(apiProviderStr);
-				aPro[finalKey] = value;
-				panelToKeyMap[index] = finalKey;
-			} else {
-				// Same provider, just update the value
-				aPro[existingAProKey] = value;
-			}
-		} else {
-			// This is a new entry
-			let finalKey = generateUniqueKey(apiProviderStr);
-			aPro[finalKey] = value;
-			panelToKeyMap[index] = finalKey;
-		}
-		
+		ensureSingleInputRow();
 		updateLocalStorage();
 	}
-	
+
+	// INIT: one empty input row; YAML box shows stored keys
+	ensureSingleInputRow();
+	updateLocalStorage();
+
+	$('#addApi').click(function() {
+		var provider = $('#apiProvider1').val();
+		if (provider === 'Other') {
+			provider = $('#apiProviderOther1').val().trim();
+		}
+		var keyVal = $('#apiKey1').val().trim();
+		if (!provider || !keyVal) {
+			return;
+		}
+		provider = provider.replace(/\s*\(\d+\)$/, "");
+		saveUndoState();
+		var finalKey = generateUniqueKey(provider);
+		aPro[finalKey] = keyVal;
+		updateLocalStorage();
+		clearInputRow();
+	});
+
+	$(document).on('change', 'select[id^="apiProvider"]', function() {
+		var index = $(this).attr('id').match(/\d+/)[0];
+		var newKey = $(this).val();
+		if (newKey == 'Other') {
+			$('#apiProviderOther' + index).show();
+		} else {
+			$('#apiProviderOther' + index).hide();
+		}
+	});
+
 	function generateUniqueKey(baseKey) {
 		// Check if this exact key already exists
 		if (!aPro.hasOwnProperty(baseKey)) {
@@ -463,15 +272,10 @@ $(document).ready(function() {
 			try {
 				const parsed = JSON.parse(undoData);
 				aPro = JSON.parse(parsed.aPro);
-				$('#aProOutputYaml').val(parsed.yamlString);
-				
 				updateLocalStorage();
-				populateRepeatingSections();
-				
-				// Clear undo data and hide button
+				ensureSingleInputRow();
 				localStorage.removeItem('localStoragePrior');
 				$('#undoBtn').hide();
-				
 				if (undoTimer) {
 					clearTimeout(undoTimer);
 				}
@@ -512,15 +316,9 @@ $(document).ready(function() {
 		if (hasDuplicateKeys($('#aProOutputYaml').val())) {
 			alert("Duplicate provides. Please add (2) after second instance.");
 		} else {
-			aPro = jsyaml.load($('#aProOutputYaml').val()); // From yaml textbox.
+			aPro = jsyaml.load($('#aProOutputYaml').val()) || {};
 			updateLocalStorage();
-			if (countKeyValuePairs(aPro) == 0) {
-				if ($('#formContainer').is(':empty')) {
-					$('#formContainer').append(generateRepeatingSection(1));
-				}
-			} else {
-			  populateRepeatingSections();
-			}
+			ensureSingleInputRow();
 		}
 	}
 	
@@ -570,12 +368,12 @@ $(document).ready(function() {
 	});
 
 	$('#clearAll').click(function() {
-		saveUndoState(); // Save state before clearing
+		saveUndoState();
 		localStorage.removeItem('aPro');
-	    aPro = {};
-	    panelToKeyMap = {}; // Clear mappings
-	    populateRepeatingSections();
-	    $('#formContainer').append(generateRepeatingSection(1));
+		aPro = {};
+		updateLocalStorage();
+		ensureSingleInputRow();
+		clearInputRow();
 	});
 	
 });
@@ -601,7 +399,7 @@ function toggleVisibility(fieldId) {
 	Keys reside in local browser storage.<br><br>
 
 	<div id="formContainer"></div>
-	<button id="addApi" class="button button-green">Add API</button>
+	<button id="addApi" class="button button-green">Add</button>
 	<button id="clearAll" class="button">Clear All</button>
 	<button id="undoBtn" class="button button-undo" style="display: none;">Undo</button>
 


### PR DESCRIPTION
refactored the api-keys page so that the input row is cleared as soon as the key is added.

adding first key:

<img width="1203" height="369" alt="Screenshot 2026-02-11 at 4 14 40 PM" src="https://github.com/user-attachments/assets/543c472b-ab03-4cd1-ad70-8c2c33004c38" />

second key in the input box:
<img width="1203" height="369" alt="Screenshot 2026-02-11 at 4 15 56 PM" src="https://github.com/user-attachments/assets/34186ca2-25f8-4748-bfa1-b1ed7cc44269" />

After adding the key the input box is cleared (Repeating input boxes function is removed)
<img width="1203" height="369" alt="Screenshot 2026-02-11 at 4 16 24 PM" src="https://github.com/user-attachments/assets/a4e4583f-f76e-41e3-8c46-7e48d32e875e" />

Editing the keys can be done in the box below the input. Tested the edit option as well.
<img width="1203" height="369" alt="Screenshot 2026-02-11 at 4 22 22 PM" src="https://github.com/user-attachments/assets/452b0377-257a-47f8-8405-d5ec4edb9d64" />

<img width="1203" height="369" alt="Screenshot 2026-02-11 at 4 22 38 PM" src="https://github.com/user-attachments/assets/443f3493-8c82-4951-b9c1-1db3c7d6ebcc" />

Updated local storage with previous data as well
<img width="1203" height="108" alt="Screenshot 2026-02-11 at 4 23 50 PM" src="https://github.com/user-attachments/assets/16c6bbf4-57ad-4c67-bb4b-a3c96d6e02b5" />
